### PR TITLE
Fix CPU consuming when there are no sql object to save.

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/database/SQLUpdate.java
+++ b/civcraft/src/com/avrgaming/civcraft/database/SQLUpdate.java
@@ -50,6 +50,9 @@ public class SQLUpdate implements Runnable {
 				
 				SQLObject obj = saveObjects.poll();
 				if (obj == null) {
+					if (saveObjects.isEmpty()) {
+						Thread.sleep(500);
+					}
 					continue;
 				}
 				


### PR DESCRIPTION
add sleep when the queue of sql is empty.
avoiding cpu consume.

a weird bug in threading.
when using the threading. it should be a sleep function when queue is all empty.
It is a common sense in busy-waiting.
