### PR TITLE
Balancing the buffs from trade goodies

### DIFF
--- a/civcraft/data/buffs.yml
+++ b/civcraft/data/buffs.yml
@@ -29,8 +29,8 @@ buffs:
 
     - id: 'buff_monopoly'
       name: 'Monopoly'
-      description: 'Increases coin output from all trade goods in use by <lightgreen>3%<r> <gold>Stackable<r>'
-      value: '0.03'
+      description: 'Increases coin output from all trade goods in use by <lightgreen>15%<r> <gold>Stackable<r>'
+      value: '0.15'
       stackable: true
       parent:
     
@@ -78,8 +78,8 @@ buffs:
 
     - id: 'buff_fire_bomb'
       name: 'Fire Bomb'
-      description: 'Increases damage of arrow/cannon towers by a <lightgreen>10%<r> Also makes arrow towers shoot flaming arrows <gold>Stackable<r>'
-      value: '0.1'
+      description: 'Increases damage of arrow/cannon towers by a <lightgreen>50%<r> Also makes arrow towers shoot flaming arrows <gold>Stackable<r>'
+      value: '0.5'
       stackable: false
       parent:
 


### PR DESCRIPTION
Suggested pull: Changed the Monopoly buff to 15% since 3% is very low and will make trades useless
Changed Fire Bomb to 50% damage instead of 10% since 10% is very low and useless. ( 7dmg arrow tower will do 7.7 damage, too low..)
