### PR TITLE
Changed camp "durability"

### DIFF
--- a/civcraft/data/camp.yml
+++ b/civcraft/data/camp.yml
@@ -9,7 +9,7 @@ camp:
     regen_rate: 2
 
     # Number of hours a camp can survive without coal.
-    firepoints: 48
+    firepoints: 24
 
     # Number of coal it takes to revive one hour worth
     # of camp life.


### PR DESCRIPTION
Changed the camp durability from 48h to 24h since it's pretty useless to have, you can get a civ in 36?..
