### PR TITLE
Changed civ join cooldown

### DIFF
--- a/civcraft/data/civ.yml
+++ b/civcraft/data/civ.yml
@@ -31,7 +31,7 @@ global:
    starting_coins: 250.0
 
    # Number of hours that must pass before a resident can join a different civ
-   join_civ_cooldown: 24
+   join_civ_cooldown: 12
 
    # Distance things must be built away from spawn.
    distance_from_spawn: 1000.0
@@ -68,7 +68,7 @@ global:
 
 civ:
     # Amount of coins required to start a civilization
-    cost: 100000.0
+    # cost: 100000.0
     
     # Amount of static upkeep civ's pay for each new town(minus the capitol)
     town_upkeep: 500.0


### PR DESCRIPTION
Reduced cooldown to 12h, 24h is way to long, saw some people quit couple of phases ago
Disabled the amount of coins to start civ cost, phase 4 content
