### PR TITLE
Changed trade goodie spawnrate

### DIFF
--- a/civcraft/data/goods.yml
+++ b/civcraft/data/goods.yml
@@ -25,7 +25,7 @@ generation:
     chunks_min: 15
 
     # Maximum number of chunks trade goods should be apart
-    chunks_max: 40
+    chunks_max: 30
 
     # World size in x chunks (radius)
     chunks_x: 625


### PR DESCRIPTION
Changed the chunks since now trade goodies can be very very far away.. lvl 5-6-7 culture without goodie at all..
