### PR TITLE
Arena soulbound & items fix.

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
+++ b/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
@@ -1,3 +1,6 @@
+// changelog:
+// https://github.com/ataranlen/civcraft/pull/73/commits/a34dd3a5bbc71b503f8dcc386fce3801abd25900
+
 package com.avrgaming.civcraft.arena;
 
 
@@ -100,18 +103,11 @@ public class Arena {
 			team.setTeamColor(CivColor.Gold);
 		}
 		
-		//team.getScoreboardTeam().setPrefix(team.getTeamColor()+"["+team.getName()+"]");
-		
 		for (Resident resident : team.teamMembers) {
 			try {
 			CivGlobal.getPlayer(resident);
 			} catch (CivException e) {
 				continue;
-			}
-			
-			if (!resident.isUsesAntiCheat()) {
-				throw new CivException(resident.getName()+" must be using anti-cheat in order to join the arena.");
-                                throw new CivException(admin.getName()+" getName() does not using anticheat and tried connect to arena.");
 			}
 			
 			try {
@@ -168,12 +164,14 @@ public class Arena {
 		LoreCraftableMaterial craftMat = LoreCraftableMaterial.getCraftMaterialFromId(id);
 		ItemStack stack = LoreCraftableMaterial.spawn(craftMat);
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+        stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementSoulBound"));
 		inv.addItem(stack);
 	}
 	
 	private void addItemToInventory(Material mat, Inventory inv, int amount) {
 		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+        stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementSoulBound"));
 		inv.addItem(stack);
 	}
 	
@@ -200,14 +198,14 @@ public class Arena {
 		LoreCraftableMaterial craftMat = LoreCraftableMaterial.getCraftMaterialFromId(id);
 		ItemStack stack = LoreCraftableMaterial.spawn(craftMat);
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
-                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
+        stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
 		inv.addItem(stack);
 	}
 	
 	private void addItemToInventory(Material mat, Inventory inv, int amount) {
 		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
-                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
+        stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
 		inv.addItem(stack);
 	}
 	
@@ -383,4 +381,3 @@ public class Arena {
 	}
 	
 }
-.

--- a/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
+++ b/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
@@ -207,7 +207,7 @@ public class Arena {
 	private void addItemToInventory(Material mat, Inventory inv, int amount) {
 		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
-                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIF_SPEED"));
+                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
 		inv.addItem(stack);
 	}
 	

--- a/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
+++ b/civcraft/src/com/avrgaming/civcraft/arena/Arena.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.Score;
 import org.bukkit.scoreboard.Scoreboard;
+import org.bukkit.enchantments.enchantment
 
 import com.avrgaming.civcraft.config.CivSettings;
 import com.avrgaming.civcraft.config.ConfigArena;
@@ -110,6 +111,7 @@ public class Arena {
 			
 			if (!resident.isUsesAntiCheat()) {
 				throw new CivException(resident.getName()+" must be using anti-cheat in order to join the arena.");
+                                throw new CivException(admin.getName()+" getName() does not using anticheat and tried connect to arena.");
 			}
 			
 			try {
@@ -128,14 +130,12 @@ public class Arena {
 	private void addCivCraftItemToInventory(String id, Inventory inv) {
 		LoreCraftableMaterial craftMat = LoreCraftableMaterial.getCraftMaterialFromId(id);
 		ItemStack stack = LoreCraftableMaterial.spawn(craftMat);
-		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementSoulBound"));
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
 		inv.addItem(stack);
 	}
 	
 	private void addItemToInventory(Material mat, Inventory inv, int amount) {
 		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
-		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementSoulBound"));
 		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
 		inv.addItem(stack);
 	}
@@ -147,20 +147,41 @@ public class Arena {
 			Inventory inv = Bukkit.createInventory(player, 9*6, resident.getName()+"'s Gear");
 
 			for (int i = 0; i < 3; i++) {
-				addCivCraftItemToInventory("mat_tungsten_sword", inv);
-				addCivCraftItemToInventory("mat_tungsten_boots", inv);
-				addCivCraftItemToInventory("mat_tungsten_chestplate", inv);
-				addCivCraftItemToInventory("mat_tungsten_leggings", inv);
-				addCivCraftItemToInventory("mat_tungsten_helmet", inv);
+				addCivCraftItemToInventory("mat_iron_sword", inv);
+				addCivCraftItemToInventory("mat_iron_boots", inv);
+				addCivCraftItemToInventory("mat_iron_chestplate", inv);
+				addCivCraftItemToInventory("mat_iron_leggings", inv);
+				addCivCraftItemToInventory("mat_iron_helmet", inv);
 		
-				addCivCraftItemToInventory("mat_marksmen_bow", inv);
-				addCivCraftItemToInventory("mat_composite_leather_boots", inv);
-				addCivCraftItemToInventory("mat_composite_leather_chestplate", inv);
-				addCivCraftItemToInventory("mat_composite_leather_leggings", inv);
-				addCivCraftItemToInventory("mat_composite_leather_helmet", inv);
+				addCivCraftItemToInventory("mat_hunting_bow", inv);
+				addCivCraftItemToInventory("mat_leather_boots", inv);
+				addCivCraftItemToInventory("mat_leather_chestplate", inv);
+				addCivCraftItemToInventory("mat_leather_leggings", inv);
+				addCivCraftItemToInventory("mat_leather_helmet", inv);
 			}
-						
-			addCivCraftItemToInventory("mat_vanilla_diamond_pickaxe", inv);
+
+			
+			playerInvs.put(resident.getName(), inv);
+		}
+        
+        	private void addCivCraftItemToInventory(String id, Inventory inv) {
+		LoreCraftableMaterial craftMat = LoreCraftableMaterial.getCraftMaterialFromId(id);
+		ItemStack stack = LoreCraftableMaterial.spawn(craftMat);
+		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+		inv.addItem(stack);
+	}
+	
+	private void addItemToInventory(Material mat, Inventory inv, int amount) {
+		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
+		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+		inv.addItem(stack);
+	}
+	
+	private void createInventory(Resident resident) {
+		Player player;
+		try {
+			player = CivGlobal.getPlayer(resident);
+			Inventory inv = Bukkit.createInventory(player, 9*6, resident.getName()+"'s Gear");
 
 			addItemToInventory(Material.ARROW, inv, 64);
 			addItemToInventory(Material.ARROW, inv, 64);
@@ -173,8 +194,33 @@ public class Arena {
 
 			
 			playerInvs.put(resident.getName(), inv);
+		}  
+
+     private void addCivCraftItemToInventory(String id, Inventory inv) {
+		LoreCraftableMaterial craftMat = LoreCraftableMaterial.getCraftMaterialFromId(id);
+		ItemStack stack = LoreCraftableMaterial.spawn(craftMat);
+		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIG_SPEED"));
+		inv.addItem(stack);
+	}
+	
+	private void addItemToInventory(Material mat, Inventory inv, int amount) {
+		ItemStack stack = ItemManager.createItemStack(ItemManager.getId(mat), amount);
+		stack = LoreCraftableMaterial.addEnhancement(stack, LoreEnhancement.enhancements.get("LoreEnhancementArenaItem"));
+                stack = LoreCraftableMaterial.addEnhancement(stack, enhancements.get("DIF_SPEED"));
+		inv.addItem(stack);
+	}
+	
+	private void createInventory(Resident resident) {
+		Player player;
+		try {
+			player = CivGlobal.getPlayer(resident);
+			Inventory inv = Bukkit.createInventory(player, 9*6, resident.getName()+"'s Gear");
+						
+			addCivCraftItemToInventory("mat_vanilla_diamond_pickaxe", inv);
 			
-		} catch (CivException e) {
+			playerInvs.put(resident.getName(), inv);
+		}   catch (CivException e) {
 			e.printStackTrace();
 		}
 		
@@ -337,3 +383,4 @@ public class Arena {
 	}
 	
 }
+.


### PR DESCRIPTION
People can take items from arena to the enderchest with one bug.Items with enchant "Arena item" cannot be enchant to soulbound.It will not benefit from t4 for one die.Fixed items t4 === t1.Damage one.2 hearts to leather, 1 heart to iron.Arrows, food, pickaxe have soulbound.
Pickaxe have efficiency V.