### PR TITLE
Fix Library Enchanting Sign Cheat-out

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/structure/Library.java
+++ b/civcraft/src/com/avrgaming/civcraft/structure/Library.java
@@ -211,7 +211,7 @@ public class Library extends Structure {
 				throw new CivException(CivSettings.localize.localizedString("library_enchant_cannotEnchant"));
 			}
 			
-			if (item.containsEnchantment(ench.enchant) && item.getEnchantmentLevel(ench.enchant) > ench.level) {
+			if (item.containsEnchantment(ench.enchant) && item.getEnchantmentLevel(ench.enchant) >= ench.level) {
 				throw new CivException(CivSettings.localize.localizedString("library_enchant_hasEnchant"));
 			}
 			


### PR DESCRIPTION
Ever since 1.8, it became easy for players, especially those who are lagging, to get the same enchant multiple times. This fixes the issue.