### PR TITLE
Vault integration

### DIFF
--- a/civcraft/data/civ.yml
+++ b/civcraft/data/civ.yml
@@ -79,6 +79,10 @@ global:
    #If true, disables EXP enchanting and repair.
    use_exp_as_currency: true
 
+   #Use Vault for player economy. Default: false
+   #Data will still be loaded from and saved to the database, but it will now be linked to Vault
+   use_vault: false
+
 
 civ:
     # Amount of coins required to start a civilization

--- a/civcraft/src/com/avrgaming/civcraft/main/CivGlobal.java
+++ b/civcraft/src/com/avrgaming/civcraft/main/CivGlobal.java
@@ -208,17 +208,6 @@ public class CivGlobal {
 		 Must be loaded before residents are loaded
 		  */
 		useEconomy = CivSettings.civConfig.getBoolean("global.use_vault");
-		if (useEconomy) {
-			try {
-				econ = Bukkit.getServicesManager().getRegistration(Economy.class).getProvider();
-				if (econ == null) {
-					CivLog.warning("global use_vault config option was set to true but no economy provider was found!");
-					useEconomy = false;
-				}
-			} catch (NoClassDefFoundError ex) {
-				useEconomy = false;
-			}
-		}
 		
 		CivLog.heading("Loading CivCraft Objects From Database");
 			

--- a/civcraft/src/com/avrgaming/civcraft/object/Civilization.java
+++ b/civcraft/src/com/avrgaming/civcraft/object/Civilization.java
@@ -128,7 +128,7 @@ public class Civilization extends SQLObject {
 		
 		this.government = CivSettings.governments.get("gov_tribalism");		
 		this.color = this.pickCivColor();		
-		this.setTreasury(new EconObject(this));
+		this.setTreasury(CivGlobal.createEconObject(this));
 		this.getTreasury().setBalance(0, false);
 		this.created_date = new Date();
 		loadSettings();
@@ -240,7 +240,7 @@ public class Civilization extends SQLObject {
 			this.created_date = new Date(ctime);
 		}
 		
-		this.setTreasury(new EconObject(this));
+		this.setTreasury(CivGlobal.createEconObject(this));
 		this.getTreasury().setBalance(rs.getDouble("coins"), false);
 		this.getTreasury().setDebt(rs.getDouble("debt"));
 

--- a/civcraft/src/com/avrgaming/civcraft/object/EconObject.java
+++ b/civcraft/src/com/avrgaming/civcraft/object/EconObject.java
@@ -23,9 +23,9 @@ public class EconObject {
 
 	private String econName;
 	private Double coins = 0.0;
-	private Double debt = 0.0;
-	private Double principalAmount = 0.0;
-	private SQLObject holder;
+	protected Double debt = 0.0;
+	protected Double principalAmount = 0.0;
+	protected SQLObject holder;
 	
 	public EconObject(SQLObject holder) {
 		this.holder = holder;

--- a/civcraft/src/com/avrgaming/civcraft/object/Resident.java
+++ b/civcraft/src/com/avrgaming/civcraft/object/Resident.java
@@ -183,7 +183,7 @@ public class Resident extends SQLObject {
 	public Resident(UUID uid, String name) throws InvalidNameException {
 		this.setName(name);
 		this.uid = uid;		
-		this.treasury = new EconObject(this);
+		this.treasury = CivGlobal.createEconObject(this);
 		setTimezoneToServerDefault();
 		loadSettings();
 	}
@@ -299,7 +299,7 @@ public class Resident extends SQLObject {
 			this.uid = UUID.fromString(rs.getString("uuid"));
 		}
 		
-		this.treasury = new EconObject(this);
+		this.treasury = CivGlobal.createEconObject(this);
 		this.getTreasury().setBalance(rs.getDouble("coins"), false);
 		this.setGivenKit(rs.getBoolean("givenKit"));
 		this.setTimezone(rs.getString("timezone"));

--- a/civcraft/src/com/avrgaming/civcraft/object/Town.java
+++ b/civcraft/src/com/avrgaming/civcraft/object/Town.java
@@ -275,7 +275,7 @@ public class Town extends SQLObject {
 		mayorGroupName = "mayors";
 		assistantGroupName = "assistants";
 
-		this.setTreasury(new EconObject(this));
+		this.setTreasury(CivGlobal.createEconObject(this));
 		this.getTreasury().setBalance(rs.getDouble("coins"), false);
 		this.setDebt(rs.getDouble("debt"));
 		
@@ -417,7 +417,7 @@ public class Town extends SQLObject {
 		this.setHammerRate(1.0);
 		this.setExtraHammers(0);	
 		this.setAccumulatedCulture(0);
-		this.setTreasury(new EconObject(this));	
+		this.setTreasury(CivGlobal.createEconObject(this));
 		this.getTreasury().setBalance(0, false);
 		this.created_date = new Date();
 
@@ -518,7 +518,7 @@ public class Town extends SQLObject {
 		Player player = Bukkit.getPlayer(res.getUUID());
 		if (player != null && CivSettings.hasITag)
 		{
-			iTag.getInstance().refreshPlayer(player, Bukkit.getOnlinePlayers());
+			iTag.getInstance().refreshPlayer(player, new HashSet<>(Bukkit.getOnlinePlayers()));
 		}
 	}
 	
@@ -1295,7 +1295,7 @@ public class Town extends SQLObject {
 		Player player = Bukkit.getPlayer(resident.getUUID());
 		if (player != null && CivSettings.hasITag)
 		{
-			iTag.getInstance().refreshPlayer(player, Bukkit.getOnlinePlayers());
+			iTag.getInstance().refreshPlayer(player, new HashSet<>(Bukkit.getOnlinePlayers()));
 		}
 	}
 

--- a/civcraft/src/com/avrgaming/civcraft/object/VaultEconObject.java
+++ b/civcraft/src/com/avrgaming/civcraft/object/VaultEconObject.java
@@ -1,0 +1,123 @@
+package com.avrgaming.civcraft.object;
+
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.OfflinePlayer;
+
+public class VaultEconObject extends EconObject {
+
+    private final Economy econ;
+    private final OfflinePlayer player;
+
+    public VaultEconObject(Economy econ, SQLObject holder, OfflinePlayer player) {
+        super(holder);
+
+        this.econ = econ;
+        this.player = player;
+    }
+
+    public double getBalance() {
+        return Math.floor(econ.getBalance(player));
+    }
+
+
+    public void setBalance(double amount) {
+        this.setBalance(amount, true);
+    }
+
+    public void setBalance(double amount, boolean save) {
+        amount = amount < 0 ? 0 : Math.floor(amount);
+
+        double current = econ.getBalance(player);
+        if (amount > current) econ.depositPlayer(player, amount - current);
+        else econ.withdrawPlayer(player, current - amount);
+
+        if (save) {
+            holder.save();
+        }
+    }
+
+    public void deposit(double amount) {
+        this.deposit(amount, true);
+    }
+
+    public void deposit(double amount, boolean save) {
+        if (amount < 0) return;
+
+        econ.depositPlayer(player, Math.floor(amount));
+
+        if (save) {
+            holder.save();
+        }
+    }
+
+    public void withdraw(double amount) {
+        this.withdraw(amount, true);
+    }
+
+    public void withdraw(double amount, boolean save) {
+        if (amount < 0) return;
+        amount = Math.floor(amount);
+
+		/*
+		 * Update the principal we use to calculate interest,
+		 * if our current balance dips below the principal,
+		 * then we subtract from the principal.
+		 */
+        synchronized(principalAmount) {
+            if (principalAmount > 0) {
+                double currentBalance = this.getBalance();
+                double diff = currentBalance - principalAmount;
+                diff -= amount;
+
+                if (diff < 0) {
+                    principalAmount -= (-diff);
+                }
+            }
+        }
+
+        econ.withdrawPlayer(player, amount);
+
+        if (save) {
+            holder.save();
+        }
+
+
+//		EconomyResponse resp;
+//		resp = CivGlobal.econ.withdrawPlayer(getEconomyName(), amount);
+//		if (resp.type == EconomyResponse.ResponseType.FAILURE) {
+//			throw new EconomyException(resp.errorMessage);
+//		}
+    }
+
+    public boolean hasEnough(double amount) {
+        return econ.has(player, Math.floor(amount));
+        //	return CivGlobal.econ.has(getEconomyName(), amount);
+    }
+
+    public boolean payTo(EconObject objToPay, double amount) {
+        if (!this.hasEnough(amount)) {
+            return false;
+        } else {
+            this.withdraw(amount);
+            objToPay.deposit(amount);
+            return true;
+        }
+    }
+
+    public double payToCreditor(EconObject objToPay, double amount) {
+        double total = 0;
+
+        if (this.hasEnough(amount)) {
+            this.withdraw(amount);
+            objToPay.deposit(amount);
+            return amount;
+        }
+
+		/* Do not have enough to pay, pay what we can and put the rest into debt. */
+        this.debt += amount - this.getBalance();
+        objToPay.deposit(this.getBalance());
+        this.withdraw(this.getBalance());
+
+        return total;
+    }
+}

--- a/civcraft/src/com/avrgaming/civcraft/structure/Stable.java
+++ b/civcraft/src/com/avrgaming/civcraft/structure/Stable.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Horse;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerInteractEvent;


### PR DESCRIPTION
This Pull Request adds a global.use-vault config option that, when set to true, will sync Vault money of a player with their civcraft money. This will still be loaded from and saved to the database, but because it is linked with Vault money can be used for and obtained from more things.

When this option is set to false (this is default) no users are affected.

The PR also contains a random added import of the Attribute class inside of Stable because it was missing and I couldn't compile without it being included.