### PR TITLE
Allow Stable Horses To Spawn

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/listener/BlockListener.java
+++ b/civcraft/src/com/avrgaming/civcraft/listener/BlockListener.java
@@ -391,7 +391,7 @@ public class BlockListener implements Listener {
 			}
 		}
 
-		class SyncTask implements Runnable {
+/*		class SyncTask implements Runnable {
 			LivingEntity entity;
 
 			public SyncTask(LivingEntity entity) {
@@ -417,7 +417,7 @@ public class BlockListener implements Listener {
 
 			CivLog.warning("Canceling horse spawn reason:"+event.getSpawnReason().name());
 			event.setCancelled(true);
-		}
+		}*/
 
 		coord.setFromLocation(event.getLocation());
 		TownChunk tc = CivGlobal.getTownChunk(coord);


### PR DESCRIPTION
Plus: Horses from Stables can now spawn.
Trade-off: Players will be able to use any horse in the wild.