### PR TITLE
Fix Mob Spawning in Town Borders

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/config/CivSettings.java
+++ b/civcraft/src/com/avrgaming/civcraft/config/CivSettings.java
@@ -542,6 +542,12 @@ public class CivSettings {
 		restrictedSpawns.put(EntityType.WITCH, 0);
 		restrictedSpawns.put(EntityType.WITHER, 0);
 		restrictedSpawns.put(EntityType.ZOMBIE, 0);
+		restrictedSpawns.put(EntityType.BAT, 0);
+		restrictedSpawns.put(EntityType.ENDERMITE, 0);
+		restrictedSpawns.put(EntityType.GUARDIAN, 0);
+		restrictedSpawns.put(EntityType.HUSK, 0);
+		restrictedSpawns.put(EntityType.STRAY, 0);
+		restrictedSpawns.put(EntityType.ZOMBIE_VILLAGER, 0);
 	}
 	
 	private static void initRestrictedItems() {


### PR DESCRIPTION
- Added bats to reduce lag and player frustration of killing them
- Since silverfish were already added, I put endermites as well
- Guardians if a player is in an ocean
- Husks spawn in deserts, Strays in specific snow biomes, and zombie villagers everywhere it seems like