### PR TITLE
Fix Mobs in Town Borders & Add Player Weapons

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/config/CivSettings.java
+++ b/civcraft/src/com/avrgaming/civcraft/config/CivSettings.java
@@ -384,9 +384,12 @@ public class CivSettings {
 	private static void initPlayerEntityWeapons() {
 		playerEntityWeapons.add(EntityType.PLAYER);
 		playerEntityWeapons.add(EntityType.ARROW);
+		playerEntityWeapons.add(EntityType.SPECTRAL_ARROW);
+		playerEntityWeapons.add(EntityType.TIPPED_ARROW);
 		playerEntityWeapons.add(EntityType.EGG);
 		playerEntityWeapons.add(EntityType.SNOWBALL);
 		playerEntityWeapons.add(EntityType.SPLASH_POTION);
+		playerEntityWeapons.add(EntityType.LINGERING_POTION);
 		playerEntityWeapons.add(EntityType.FISHING_HOOK);
 	}
 	
@@ -542,6 +545,12 @@ public class CivSettings {
 		restrictedSpawns.put(EntityType.WITCH, 0);
 		restrictedSpawns.put(EntityType.WITHER, 0);
 		restrictedSpawns.put(EntityType.ZOMBIE, 0);
+		restrictedSpawns.put(EntityType.BAT, 0);
+		restrictedSpawns.put(EntityType.ENDERMITE, 0);
+		restrictedSpawns.put(EntityType.GUARDIAN, 0);
+		restrictedSpawns.put(EntityType.HUSK, 0);
+		restrictedSpawns.put(EntityType.STRAY, 0);
+		restrictedSpawns.put(EntityType.ZOMBIE_VILLAGER, 0);
 	}
 	
 	private static void initRestrictedItems() {


### PR DESCRIPTION
Includes spectral and tipped arrows, along with lingering potions.

- Added bats to reduce lag and player frustration of killing them
- Since silverfish were already added, I put endermites as well
- Guardians if a player is in an ocean
- Husks spawn in deserts, Strays in specific snow biomes, and zombie villagers everywhere it seems like