### PR TITLE
Fix Horse And Stables Spawning

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/listener/BlockListener.java
+++ b/civcraft/src/com/avrgaming/civcraft/listener/BlockListener.java
@@ -453,11 +453,17 @@ public class BlockListener implements Listener {
 		}
 
 		if (event.getEntityType() == EntityType.HORSE) {
+			ChunkCoord coord = new ChunkCoord(event.getEntity().getLocation());
+			Stable stable = Stable.stableChunks.get(coord);
+			if (stable != null) {
+				return;
+			}
+			
 			if (event.getSpawnReason().equals(SpawnReason.DEFAULT)) {
 				TaskMaster.syncTask(new SyncTask(event.getEntity()));
 				return;
 			}
-
+			
 			CivLog.warning("Canceling horse spawn reason:"+event.getSpawnReason().name());
 			event.setCancelled(true);
 		}

--- a/civcraft/src/com/avrgaming/civcraft/structure/Stable.java
+++ b/civcraft/src/com/avrgaming/civcraft/structure/Stable.java
@@ -61,6 +61,9 @@ public class Stable extends Structure {
 	private BlockCoord muleSpawnCoord;
 	private NonMemberFeeComponent nonMemberFeeComponent;
 	
+	public HashSet<ChunkCoord> chunks = new HashSet<ChunkCoord>();
+	public static Map<ChunkCoord, Stable> stableChunks = new ConcurrentHashMap<ChunkCoord, Stable>();
+	
 	public Stable(ResultSet rs) throws SQLException, CivException {
 		super(rs);
 		nonMemberFeeComponent = new NonMemberFeeComponent(this);
@@ -71,6 +74,37 @@ public class Stable extends Structure {
 		super(center, id, town);
 		nonMemberFeeComponent = new NonMemberFeeComponent(this);
 		nonMemberFeeComponent.onSave();
+	}
+	
+	public void bindStableChunks() {
+		for (BlockCoord bcoord : this.structureBlocks.keySet()) {
+			ChunkCoord coord = new ChunkCoord(bcoord);
+			this.chunks.add(coord);
+			stableChunks.put(coord, this);
+		}
+	}
+	
+	public void unbindStableChunks() {
+		for (ChunkCoord coord : this.chunks) {
+			stableChunks.remove(coord);
+		}
+		this.chunks.clear();
+	}
+	
+	@Override
+	public void onComplete() {
+		bindStableChunks();
+	}
+	
+	@Override
+	public void onLoad() throws CivException {
+		bindStableChunks();
+	}
+	
+	@Override
+	public void delete() throws SQLException {
+		super.delete();
+		unbindStableChunks();
 	}
 	
 	public void loadSettings() {

--- a/civcraft/src/gpl/HorseModifier.java
+++ b/civcraft/src/gpl/HorseModifier.java
@@ -31,6 +31,7 @@ public class HorseModifier {
     private Object entityHorse;
     private Object nbtTagCompound;
     
+    public static String HORSE_META = "civcrafthorse";
     private static final UUID movementSpeedUID = UUID.fromString("206a89dc-ae78-4c4d-b42c-3b31db3f5a7c");
  
     /**
@@ -84,7 +85,7 @@ public class HorseModifier {
         try {
             Object entityLiving = ReflectionUtil.getMethod("getHandle", le.getClass(), 0).invoke(le);
             Object nbtTagCompound = NBTUtil.getNBTTagCompound(entityLiving);
-            return NBTUtil.hasKeys(nbtTagCompound, new String[] { "EatingHaystack", "ChestedHorse", "HasReproduced", "Bred", "Type", "Variant", "Temper", "Tame" });
+            return NBTUtil.hasKeys(nbtTagCompound, new String[] { "Bred", "EatingHaystack", "Tame" , "Temper", "Variant" });
         } catch (Exception e) {
             e.printStackTrace();
             return false;
@@ -106,8 +107,19 @@ public class HorseModifier {
     	//done??
     }
     
+    public static void setCivCraftHorse(LivingEntity entity) {
+    	entity.setMetadata(HorseModifier.HORSE_META, new FixedMetadataValue(CivCraft.getPlugin(), HorseModifier.HORSE_META));
+    }
+    
     public static boolean isCivCraftHorse(LivingEntity entity) {
+    	if (!entity.hasMetadata(HORSE_META)) {
+    		CivLog.debug("Player tried using Horse without meta: "+HORSE_META);
+    		CivMessage.global(HORSE_META);
+    		return false;
+    	}
+    	
     	if (!isHorse(entity)) {
+    		CivLog.debug("Player tried using Horse that isn't a Horse? Error in HorseModifier.java.");
     		return false;
     	}
     	


### PR DESCRIPTION
- Will bypass horse spawning in BlockListener.java to allow any horses at the stables to spawn
- Added a metadata component when horses are spawned from stables to set them civcraft horses
- When a horse is interacted with, it will check for the civcrafthorse tag. If it is not on that horse, it will be despawned.
- Also fixed an error within HorseModifier.java that had outdated NBT and would despawn horses due to an invalid check.