### PR TITLE
Fix Enchanting Accessible to Non-Civ Players

### DIFF
--- a/civcraft/src/com/avrgaming/civcraft/structure/wonders/GreatLibrary.java
+++ b/civcraft/src/com/avrgaming/civcraft/structure/wonders/GreatLibrary.java
@@ -120,7 +120,7 @@ public class GreatLibrary extends Wonder {
 			return;
 		}
 		
-		if (!resident.hasTown() || resident.getCiv() != this.getCiv()) {
+		if (resident.getCiv() != this.getCiv()) {
 			CivMessage.sendError(player, CivSettings.localize.localizedString("var_greatLibrary_nonMember",this.getCiv().getName()));
 			return;
 		}


### PR DESCRIPTION
The library is ONLY for civ members, this piece of code should not be here.